### PR TITLE
Updated example code for tilt destroy

### DIFF
--- a/tilt.js/index.html
+++ b/tilt.js/index.html
@@ -181,7 +181,7 @@
             <h3>Destroy method</h3>
             <p>Call this method will remove all events and classes from the tilt element.</p>
             <pre><code class="language-javascript">const tilt = $('.js-tilt').tilt()
-tilt.methods.destroy.call(tilt);
+tilt.tilt.destroy.call(tilt);
 </code></pre>
             <button class="js-destroy c-button">Destroy</button>
             <button class="js-enable c-button">Re-enable</button>


### PR DESCRIPTION
tilt.methods.destroy.call(tilt) was a bit confusing. Even the readme of tilt.js has correct example code.